### PR TITLE
add p4d.24xlarge

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -37,11 +37,13 @@ Parameters:
     - p3.2xlarge    # 1 GPU Tesla V100
     - p3.8xlarge    # 4 GPU Tesla V100
     - p3.16xlarge   # 8 GPU Tesla V100
+    - p4d.24xlarge   # 8 A100 @ 172.870 MH/s / 1384 MH/s total
+
     Default: g4dn.xlarge
 
   InstanceCount:
     Type: Number
-    Default: 5
+    Default: 1
     MaxValue: 10
 
   EthWallet:
@@ -107,6 +109,8 @@ Mappings:
       MaxPrice: 3.68
     p3.16xlarge:
       MaxPrice: 7.36
+    p4d.24xlarge:
+      MaxPrice: 15
 
 Resources:
 


### PR DESCRIPTION
Just out of curiosity I tried the p4d.24xlarge
I had to request a limit increase to be able to start this 96 core 8GPU beast

Results:
Eth: Average speed (5 min): 1383.154 MH/s

which will yield about $6 per hour, unfortunately the machine as a spot instance costs $9.81
And in your MH/$ metric it scores 140.767 MH/$

The machine has 8 x A100-SXM4-40GB cards and the run at +/- 170 HM/s with PhoenixMiner
yes I changed out the user data in my tests to use a different miner...

I think AWS uses something like the [dgx A100](https://www.nvidia.com/en-us/data-center/dgx-a100/) for the p4d.24xlarge

For my own mining I'll keep using a simple home rig with nvidia-docker:
https://gitlab.com/aapjeisbaas/docker-miner
https://hub.docker.com/r/aapjeisbaas/docker-miner

Thanks for the template, I had fun with it!